### PR TITLE
Handle timestamp columns

### DIFF
--- a/lib/impala.rb
+++ b/lib/impala.rb
@@ -8,6 +8,7 @@ $LOAD_PATH.push(gen_dir) unless $LOAD_PATH.include?(gen_dir)
 require 'impala/version'
 
 require 'thrift'
+require 'time'
 require 'impala/protocol'
 require 'impala/cursor'
 require 'impala/connection'

--- a/lib/impala/cursor.rb
+++ b/lib/impala/cursor.rb
@@ -116,6 +116,8 @@ module Impala
         value.to_i
       when 'double'
         value.to_f
+      when "timestamp"
+        Time.parse(value)
       else
         raise ParsingError.new("Unknown type: #{schema.type}")
       end


### PR DESCRIPTION
`timestamp` is a valid column type for Impala -- rather than raise an Exception, this parses into a `Time` object.
