### PR TITLE
Allow EXPLAIN queries

### DIFF
--- a/lib/impala.rb
+++ b/lib/impala.rb
@@ -14,7 +14,7 @@ require 'impala/cursor'
 require 'impala/connection'
 
 module Impala
-  KNOWN_COMMANDS = ['select', 'show', 'describe', 'use']
+  KNOWN_COMMANDS = ['select', 'show', 'describe', 'use', 'explain']
   DEFAULT_HOST = 'localhost'
   DEFAULT_PORT = 21000
   class InvalidQueryError < StandardError; end


### PR DESCRIPTION
Simple change to allow EXPLAIN queries, which is useful for testing the syntax of a query before running it.
