### PR TITLE
add a method to Cursor for getting the 'runtime profile' string

### DIFF
--- a/lib/impala/cursor.rb
+++ b/lib/impala/cursor.rb
@@ -70,6 +70,10 @@ module Impala
       !@done || !@row_buffer.empty?
     end
 
+    def runtime_profile
+      @service.GetRuntimeProfile(@handle)
+    end
+
     private
 
     def metadata
@@ -130,10 +134,6 @@ module Impala
       else
         raise ParsingError.new("Unknown type: #{schema.type}")
       end
-    end
-
-    def runtime_profile
-      @service.GetRuntimeProfile(@handle)
     end
   end
 end

--- a/test/test_impala_connected.rb
+++ b/test/test_impala_connected.rb
@@ -77,6 +77,12 @@ describe 'connected tests' do
     it 'can successfully refresh the metadata store' do
       ret = @connection.refresh
     end
+
+    it 'can get the runtime profile from a cursor' do
+      cursor = @connection.execute('SELECT NOW() as foo')
+      ret = cursor.runtime_profile
+      assert_instance_of(String, ret, "the result should be a string")
+    end
   end
 
   describe 'with a test database' do


### PR DESCRIPTION
Next step would be to try to do some parsing of this to produce structured results, it's an insanely information-dense thing.
