### PR TITLE
Remove KNOWN_COMMANDS check

### DIFF
--- a/lib/impala.rb
+++ b/lib/impala.rb
@@ -14,7 +14,6 @@ require 'impala/cursor'
 require 'impala/connection'
 
 module Impala
-  KNOWN_COMMANDS = ['select', 'insert', 'show', 'describe', 'use', 'explain', 'create', 'drop', 'invalidate', 'with', 'alter']
   DEFAULT_HOST = 'localhost'
   DEFAULT_PORT = 21000
   class InvalidQueryError < StandardError; end

--- a/lib/impala/connection.rb
+++ b/lib/impala/connection.rb
@@ -84,10 +84,6 @@ module Impala
       raise InvalidQueryError.new("Empty query") if words.empty?
 
       command = words.first.downcase
-      if !KNOWN_COMMANDS.include?(command)
-        raise InvalidQueryError.new("Unrecognized command: '#{words.first}'")
-      end
-
       ([command] + words[1..-1]).join(' ')
     end
 


### PR DESCRIPTION
Each time new command gets introduced this will have to be extended.
Outsource this check to Thrift which will raise informative `Impala::Protocol::Beeswax::BeeswaxException` instead

E.g.:

```
"Impala::Protocol::Beeswax::BeeswaxException", "AnalysisException: Syntax error in line 1:\nwat\n^\nEncountered: IDENTIFIER\nExpected: ALTER, COMPUTE, CREATE, DESCRIBE, DROP, EXPLAIN, INSERT, INVALIDATE, LOAD, REFRESH, SELECT, SHOW, USE, VALUES, WITH\n\nCAUSED BY: Exception: Syntax error"
```
