### PR TITLE
Add smallint data type conversion

### DIFF
--- a/lib/impala/cursor.rb
+++ b/lib/impala/cursor.rb
@@ -121,7 +121,7 @@ module Impala
         else
           raise ParsingError.new("Invalid value for boolean: #{value}")
         end
-      when 'tinyint', 'int', 'bigint'
+      when 'tinyint', 'smallint', 'int', 'bigint'
         value.to_i
       when 'double', 'float'
         value.to_f

--- a/test/test_impala_connected.rb
+++ b/test/test_impala_connected.rb
@@ -59,6 +59,11 @@ describe 'connected tests' do
       assert_equal([{:foo=>1.23}], ret, "the result should be a float")
     end
 
+    it 'can handle smallint values' do
+      ret = @connection.query('SELECT CAST(123 AS smallint) AS foo')
+      assert_equal([{:foo=>123}], ret, "the result should be an integer")
+    end
+
     it 'can handle float values' do
       ret = @connection.query('SELECT CAST(1.23 AS float) as foo')
       assert_instance_of(Float, ret.first[:foo], "the result should be a float")


### PR DESCRIPTION
Impala has `smallint` data type. 

http://www.cloudera.com/content/cloudera-content/cloudera-docs/Impala/latest/Installing-and-Using-Impala/ciiu_datatypes.html?scroll=smallint_unique_1
